### PR TITLE
Add host-power tag for ability to exclude tests against OpenBMC running under QEMU

### DIFF
--- a/tests/test_eventlog.robot
+++ b/tests/test_eventlog.robot
@@ -117,7 +117,7 @@ deleting log after obmc-phosphor-event.service restart
     ${resp} =    openbmc post request     ${deluri}    data=${NIL}
     should be equal as strings      ${resp.status_code}     ${HTTP_OK}
 
-makeing new log after obmc-phosphor-event.service restart
+making new log after obmc-phosphor-event.service restart
     [Documentation]     This is for testing event creation after the
     ...                 event service is restarted.
     Open Connection And Log In

--- a/tests/test_eventlog.robot
+++ b/tests/test_eventlog.robot
@@ -72,7 +72,7 @@ delete the log
     should be equal as strings      ${resp.status_code}     ${HTTP_NOT_FOUND}
 
 Intermixed delete
-    [Documentation]     This testcase is for excersicing caching impleted,
+    [Documentation]     This testcase exercises the cache implementation.
     ...                 Steps:
     ...                     write three logs
     ...                     delete middle log

--- a/tests/test_occ_powercap.robot
+++ b/tests/test_occ_powercap.robot
@@ -130,6 +130,7 @@ Get Chassis URI
 
 Host PowerOn
     [Documentation]     Keyword to poweron the host and wait till boot up
+    [Tags] host-power
     ${chassis_uri}=     Get Chassis URI
     Should Not Be Empty     ${chassis_uri}      msg=Failed to get the chassis URI in the openbmc machine
     ${data}=    create dictionary   data=@{EMPTY}


### PR DESCRIPTION
The main feature of the series is to enable a complete test run when OpenBMC is running under QEMU using the palmetto-bmc machine type. There are some further commits that fix typos seen during test runs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mkumatag/openbmc-automation/41)

<!-- Reviewable:end -->
