### PR TITLE
Remove system specific tests that fail on a different system

### DIFF
--- a/data/model.py
+++ b/data/model.py
@@ -19,7 +19,7 @@ def get_sensor(module_name, value):
 def get_inventory_sensor (module_name, value):
 	m = imp.load_source('module.name', module_name)
 
-	value = string.replace(value, '/org/openbmc/inventory', '<inventory_root>')
+	value = string.replace(value, m.INVENTORY_ROOT, '<inventory_root>')
 
 	for i in m.ID_LOOKUP['SENSOR']:
 
@@ -29,7 +29,31 @@ def get_inventory_sensor (module_name, value):
 	return 0xFF
 
 
+def get_inventory_list(module_name):
 
+	l = []
+	m = imp.load_source('module.name', module_name)
+
+	for i in m.ID_LOOKUP['FRU']:
+		s = m.ID_LOOKUP['FRU'][i]
+		s = s.replace('<inventory_root>',m.INVENTORY_ROOT)
+		l.append(s)
+
+	return l
+
+def get_inventory_fru_type_list(module_name, fru_type):
+
+	l = []
+	m = imp.load_source('module.name', module_name)
+
+	for i in m.FRU_INSTANCES.keys():
+		if m.FRU_INSTANCES[i]['fru_type'] == fru_type:
+			print 'found one'
+
+			s = i.replace('<inventory_root>',m.INVENTORY_ROOT)
+			l.append(s)
+
+	return l
 
 def call_keyword(keyword):
     return BuiltIn().run_keyword(keyword)

--- a/lib/rest_client.robot
+++ b/lib/rest_client.robot
@@ -136,7 +136,7 @@ Write Attribute
 
 Read Properties
     [arguments]    ${uri}
-    ${resp} =   OpenBMC Get Request    ${uri}
+    ${resp} =   OpenBMC Get Request    ${uri}   timeout=10
     Should Be Equal As Strings    ${resp.status_code}    ${HTTP_OK}
     ${content}=     To Json    ${resp.content}
     [return]    ${content["data"]}

--- a/lib/utils.robot
+++ b/lib/utils.robot
@@ -14,3 +14,29 @@ Ping Host
     ${RC}   ${output} =     Run and return RC and Output    ping -c 4 ${host}
     Log     RC: ${RC}\nOutput:\n${output}
     Should be equal     ${RC}   ${0}
+
+Get Boot Progress
+    ${state} =     Read Attribute    /org/openbmc/sensors/host/BootProgress    value
+    [return]  ${state}
+
+Is Power On
+    ${state} =    Get Boot Progress
+    Should be equal   ${state}     FW Progress, Starting OS
+
+Is Power Off
+    ${state} =    Get Boot Progress
+    Should be equal   ${state}     Off
+
+Power On Host
+    @{arglist}=   Create List
+    ${args}=     Create Dictionary    data=@{arglist}
+    ${resp}=   Call Method    /org/openbmc/control/chassis0/    powerOn    data=${args}
+    should be equal as strings      ${resp.status_code}     ${HTTP_OK}
+    Wait Until Keyword Succeeds	  3 min    	10 sec    Is Power On
+
+Power Off Host
+    @{arglist}=   Create List
+    ${args}=     Create Dictionary    data=@{arglist}
+    ${resp}=   Call Method    /org/openbmc/control/chassis0/    powerOff   data=${args}
+    should be equal as strings      ${resp.status_code}     ${HTTP_OK}
+    Wait Until Keyword Succeeds	  1 min    	10 sec    Is Power Off

--- a/tests/security/test_ssl.robot
+++ b/tests/security/test_ssl.robot
@@ -25,8 +25,8 @@ Test non-SSL Connection to port 80
     [Documentation]     This testcase is for test to check OpenBMC machine
     ...     will not accepts the non-secure connection that is with http to
     ...     port 80 and expect a connection error
-    Create Session    openbmc    http://${OPENBMC_HOST}/
-    Run Keyword And Expect Error    ConnectionError*   Get Request    openbmc   /list
+    Create Session    openbmc    http://${OPENBMC_HOST}/    timeout=3
+    Run Keyword And Expect Error    ConnectTimeout*   Get Request    openbmc   /list
 
 Test non-SSL Connection to port 443
     [Documentation]     This testcase is for test to check OpenBMC machine

--- a/tests/test_ac_cycles.robot
+++ b/tests/test_ac_cycles.robot
@@ -9,6 +9,7 @@ Library         SSHLibrary
 
 *** Test Cases ***
 Test openbmc buster
+    [Tags]      reboot_tests
     Open Connection And Log In
     ${output}=  Execute Command    find /var/lib -type f |xargs -n 1 touch
     PDU Power Cycle

--- a/tests/test_obmcrest.robot
+++ b/tests/test_obmcrest.robot
@@ -290,17 +290,17 @@ post method org/openbmc/records/events/action/acceptTestMessage invalid args
     ${json} =   to json         ${resp.content}
     should be equal as strings      ${json['status']}       error
 
-post method /org/openbmc/control/fan0/action/setspeed with args
-    ${fan_uri}=     Get Fan Speed Interface
-    ${SPEED}=   Set Variable    ${200}
-    @{speed_list} =   Create List     ${SPEED}
-    ${data} =   create dictionary   data=@{speed_list}
-    ${resp} =   openbmc post request    ${fan_uri}/action/setValue      data=${data}
+post method org/openbmc/sensors/host/BootCount with args
+    ${uri} =     Set Variable   /org/openbmc/sensors/host/BootCount
+    ${COUNT}=   Set Variable    ${3}
+    @{count_list} =   Create List     ${COUNT}
+    ${data} =   create dictionary   data=@{count_list}
+    ${resp} =   openbmc post request    ${uri}/action/setValue      data=${data}
     should be equal as strings      ${resp.status_code}     ${HTTP_OK}
     ${json} =   to json         ${resp.content}
     should be equal as strings      ${json['status']}       ok
-    ${content}=     Read Attribute      ${fan_uri}   value
-    Should Be Equal     ${content}      ${SPEED}
+    ${content}=     Read Attribute      ${uri}   value
+    Should Be Equal     ${content}      ${COUNT}
 
 delete method org/openbmc/records/events/action/acceptTestMessage
     ${resp} =   openbmc delete request  org/openbmc/records/events/action/acceptTestMessage
@@ -322,16 +322,6 @@ post method org/openbmc/records/events/action/acceptTestMessage no args
     should be equal as strings      ${json['status']}       ok
 
 ***keywords***
-Get Fan Speed Interface
-    ${resp}=    OpenBMC Get Request     /org/openbmc/sensors/speed/
-    should be equal as strings      ${resp.status_code}     ${HTTP_OK}     msg=Unable to get any fan controls
-    ${jsondata}=   To Json    ${resp.content}
-    log     ${jsondata}
-    : FOR    ${ELEMENT}    IN    @{jsondata["data"]}
-    \   log     ${ELEMENT}
-    \   ${found}=   Get Lines Matching Pattern      ${ELEMENT}      *speed/fan*
-    \   Return From Keyword If     '${found}' != ''     ${found}
-
 Get Power Control Interface
     ${resp}=    OpenBMC Get Request     /org/openbmc/control/
     should be equal as strings      ${resp.status_code}     ${HTTP_OK}     msg=Unable to get any controls - /org/openbmc/control/

--- a/tests/test_occ_powercap.robot
+++ b/tests/test_occ_powercap.robot
@@ -3,8 +3,9 @@ Documentation           This suite is for testing OCC: Power capping setting
 
 Resource                ../lib/rest_client.robot
 Resource                ../lib/resource.txt
+Resource                ../lib/utils.robot
 
-Suite Setup            Host PowerOn
+Suite Setup            Power On Host
 
 *** Test Cases ***
 
@@ -127,22 +128,3 @@ Get Chassis URI
     \   log     ${ELEMENT}
     \   ${found}=   Get Lines Matching Pattern      ${ELEMENT}      *control/chassis*
     \   Return From Keyword If     '${found}' != ''     ${found}
-
-Host PowerOn
-    [Documentation]     Keyword to poweron the host and wait till boot up
-    ${chassis_uri}=     Get Chassis URI
-    Should Not Be Empty     ${chassis_uri}      msg=Failed to get the chassis URI in the openbmc machine
-    ${data}=    create dictionary   data=@{EMPTY}
-    ${resp}=    openbmc post request     ${chassis_uri}/action/powerOn      data=${data}
-    Wait For Host To Bootup
-    Sleep   120sec
-
-Wait For Host To Bootup
-    [Documentation]     Polling method to wait till HOST OS boots up
-    Wait Until Keyword Succeeds     10min    5 sec   Host Booted
-
-Host Booted
-    ${data}=    create dictionary   data=@{EMPTY}
-    ${resp}=    openbmc post request     /org/openbmc/managers/System/action/getSystemState      data=${data}
-    ${jsondata}=   To Json    ${resp.content}
-    Should Be Equal     HOST_BOOTED     ${jsondata["data"]}


### PR DESCRIPTION
Fixes for timeouts and the use of sleep to power on the system
Fix test cases that assumed barreleye or palmetto and failed on the other

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mkumatag/openbmc-automation/51)

<!-- Reviewable:end -->
