### PR TITLE
Cascade timeouts error causes REST outage

### DIFF
--- a/tests/test_eventlog.robot
+++ b/tests/test_eventlog.robot
@@ -13,7 +13,7 @@ Library         SSHLibrary
 *** Variables ***
 &{NIL}  data=@{EMPTY}
 ${SYSTEM_SHUTDOWN_TIME}     1min
-${WAIT_FOR_SERVICES_UP}     2min
+${WAIT_FOR_SERVICES_UP}     3min
 
 *** Test Cases ***
 


### PR DESCRIPTION
It turns out that the rocket rest server used for OpenBMC has a bug.  If we call the REST interface too early in the boot then it hits a code path with cripples it.  There is an outstanding issue opened and inthe mean time to allow the rest of the test suites to finish I will extended the IPL delay to 3 minutes instead of 2

https://github.com/openbmc/openbmc/issues/306

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mkumatag/openbmc-automation/56)

<!-- Reviewable:end -->
