### PR TITLE
urllib3 throws InsecureRequestWarning: Unverified HTTPS request is being made

### DIFF
--- a/lib/disable_warning_urllib.py
+++ b/lib/disable_warning_urllib.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python
+import logging
+import warnings
+import httplib
+
+warnings.filterwarnings("ignore")
+
+# Hijack the HTTP lib logger message and Log only once
+requests_log = logging.getLogger("requests.packages.urllib3")
+requests_log.setLevel(logging.CRITICAL)
+requests_log.propagate = False
+
+class disable_warning_urlib():
+    def do_nothing():
+        return
+

--- a/lib/rest_client.robot
+++ b/lib/rest_client.robot
@@ -4,6 +4,7 @@ Library           String
 Library           RequestsLibrary.RequestsKeywords
 Library           OperatingSystem
 Resource          ../lib/resource.txt
+Library           ../lib/disable_warning_urlib.py
 
 *** Variables ***
 # Response codes


### PR DESCRIPTION
urllib3 throws Unverified HTTPS request and other connection related warnings on the console. Even though this warning is harmless but we are suppressing this for reason for automation cleaner console output. 

These WARN messages were supposed to be suppressed by the higher version of the Python 2.7.xx but due to package dependencies around Python, robot framework and tox those warning message still remains.

Using native Python logger and warnings, this message log level is suppressed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mkumatag/openbmc-automation/66)

<!-- Reviewable:end -->
