### PR TITLE
Fixing in the class name and file name miss match

### DIFF
--- a/lib/disable_warning_urllib.py
+++ b/lib/disable_warning_urllib.py
@@ -10,7 +10,7 @@ requests_log = logging.getLogger("requests.packages.urllib3")
 requests_log.setLevel(logging.CRITICAL)
 requests_log.propagate = False
 
-class disable_warning_urlib():
+class disable_warning_urllib():
     def do_nothing():
         return
 

--- a/lib/rest_client.robot
+++ b/lib/rest_client.robot
@@ -4,7 +4,7 @@ Library           String
 Library           RequestsLibrary.RequestsKeywords
 Library           OperatingSystem
 Resource          ../lib/resource.txt
-Library           ../lib/disable_warning_urlib.py
+Library           ../lib/disable_warning_urllib.py
 
 *** Variables ***
 # Response codes


### PR DESCRIPTION
Fixing the following..   The class name and file name missmatch

[ WARN ] Imported library '/home/rango/FTC_OPENBMC_TEST/openbmc-automation/lib/disable_warning_urllib.py' contains no keywords.

[ ERROR ] Error in file '/home/rango/FTC_OPENBMC_TEST/openbmc-automation/lib/rest_client.robot': Test library 'disable_warning_urlib.py' does not exist.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mkumatag/openbmc-automation/69)

<!-- Reviewable:end -->
